### PR TITLE
When priceperpoint is too low decimal, the app crashes

### DIFF
--- a/app/(pages)/marketplace/[pointName-pointAddress]/page.tsx
+++ b/app/(pages)/marketplace/[pointName-pointAddress]/page.tsx
@@ -89,7 +89,7 @@ const PointPage = () => {
     });
     console.log(formattedListings, "formattedListings");
     setFormattedBlockchainListings(formattedListings);
-  }, [isBlockchainLoading, decimals, listingData]);
+  }, [isBlockchainLoading]);
   useEffect(() => {
     if (listingCount != 0) {
       fetchListings();

--- a/components/forms/create-offer-form.tsx
+++ b/components/forms/create-offer-form.tsx
@@ -62,9 +62,7 @@ const CreateOfferForm: React.FC<Props> = ({ onCanceled }) => {
     offerType: z.string(),
     point: z.string().min(1, "Point is required"),
     // paymentToken: z.string(),
-    pricePerPoint: z.coerce.number().positive({
-      message: "Price must be greater than 0",
-    }),
+    pricePerPoint: z.coerce.string(),
     amount: z.string().min(1, "Amount is required"),
     fillType: z.string().min(1, "Fill type is required"),
   });
@@ -75,7 +73,7 @@ const CreateOfferForm: React.FC<Props> = ({ onCanceled }) => {
       amount: "",
       point: "",
       // paymentToken: "",
-      pricePerPoint: 0,
+      pricePerPoint: "0",
       offerType: "sell",
       fillType: "partial",
     },
@@ -124,10 +122,7 @@ const CreateOfferForm: React.FC<Props> = ({ onCanceled }) => {
     }
   }, [form, pathName]);
 
-  const totalPriceInEth = toUnits(
-    String(Number(toUnits(amount, decimals)) * Number(pricePerPoint)),
-    18
-  );
+  const totalPriceInEth = toUnits(amount, decimals) * toUnits(String(pricePerPoint), 18);
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     console.log("submit", values);
@@ -333,12 +328,12 @@ const CreateOfferForm: React.FC<Props> = ({ onCanceled }) => {
                   onValueChange={
                     isPointDetailPage
                       ? (value) => {
-                          field.onChange(value === "" ? null : null);
-                        }
+                        field.onChange(value === "" ? null : null);
+                      }
                       : (value) => {
-                          field.onChange(value);
-                          value && setSelectedPoint(value);
-                        }
+                        field.onChange(value);
+                        value && setSelectedPoint(value);
+                      }
                   }
                   value={isPointDetailPage ? selectedPoint : field.value}
                   disabled={isPointDetailPage}


### PR DESCRIPTION
# Pull Request Template

## Description

When priceperpoint is too low decimal, the app crashes
TODO: Check the zod validation for priceperpoint. Also, we can let user add input and keep the validation for the end. The app should not crash.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Screenshots (if applicable)

## Additional Context

Add any other context or screenshots about the feature request here.
