### PR TITLE
feat: dont allow redeem if minting is off

### DIFF
--- a/components/customer-dashboard.tsx
+++ b/components/customer-dashboard.tsx
@@ -6,7 +6,12 @@ import { Button } from "./ui/button";
 import { apiService } from "@/services/api.service";
 import useCustomerStore from "@/store/customerStore";
 import { toast } from "sonner";
-import { PreparedTransaction, prepareContractCall } from "thirdweb";
+import {
+  Address,
+  PreparedTransaction,
+  prepareContractCall,
+  readContract,
+} from "thirdweb";
 import { useSendAndConfirmTransaction } from "thirdweb/react";
 import { useEffect, useState } from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
@@ -73,6 +78,16 @@ const CustomerDashboard = () => {
     enabled: !!customerStore?.customer?.id,
   });
 
+  const getMintStatus = async (address: Address) => {
+    if (!address) return;
+    const data = await readContract({
+      contract: monetPointsContractFactory(address),
+      method: "mintingSwitch",
+      params: [],
+    });
+    return data;
+  };
+
   const {
     mutate: sendTransaction,
     isPending,
@@ -89,9 +104,14 @@ const CustomerDashboard = () => {
             customerStore?.customer?.id!,
             point.company!.point_contract_address!,
           );
+          const mintStatus = await getMintStatus(
+            point.company!.point_contract_address! as Address,
+          );
+
           return {
             ...point,
             onChainPoints: onChainPoints.data.points,
+            mintStatus: mintStatus,
           };
         }),
       );
@@ -256,7 +276,12 @@ const CustomerDashboard = () => {
                       pointAddress={point?.company?.point_contract_address}
                       offChain={point.points}
                       onChain={point.onChainPoints}
-                      onRedeemClick={() => handleRedeemPoints(point)}
+                      onRedeemClick={
+                        point.mintStatus
+                          ? () => handleRedeemPoints(point)
+                          : () =>
+                              toast.error("Minting is disabled for this token")
+                      }
                     />
                   ))
                 : customerPointsResponse?.data?.points.map((point) => (


### PR DESCRIPTION
# Pull Request Template

## Description

User will not be able to open redeem points form from customer dashboard if the minting is disabled for a particular point.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Screenshots (if applicable)

## Additional Context

Add any other context or screenshots about the feature request here.
